### PR TITLE
Support deserializing natural key objects

### DIFF
--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -1,4 +1,6 @@
 import copy
+from collections import namedtuple
+
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 try:
@@ -54,6 +56,9 @@ class JSONCharFormField(JSONFormFieldBase, fields.CharField):
     pass
 
 
+DeserializedValue = namedtuple('DeserializedValue', 'value')
+
+
 class JSONFieldBase(six.with_metaclass(SubfieldBase, models.Field)):
 
     def __init__(self, *args, **kwargs):
@@ -71,6 +76,10 @@ class JSONFieldBase(six.with_metaclass(SubfieldBase, models.Field)):
         SubfieldBase metaclass has been modified to call this method instead of
         to_python so that we can check the obj state and determine if it needs to be
         deserialized"""
+
+        if isinstance(value, DeserializedValue):
+            # value already deserialized, just return it
+            return value.value
 
         try:
             if obj._state.adding:
@@ -95,6 +104,12 @@ class JSONFieldBase(six.with_metaclass(SubfieldBase, models.Field)):
     def to_python(self, value):
         """The SubfieldBase metaclass calls pre_init instead of to_python, however to_python
         is still necessary for Django's deserializer"""
+        if value and isinstance(value, six.string_types):
+            try:
+                # return a DeserializedValue object to indicate that we've already done the deserialization
+                return DeserializedValue(json.loads(value, **self.load_kwargs))
+            except ValueError:
+                raise ValidationError(_("Enter valid JSON"), )
         return value
 
     def get_db_prep_value(self, value, connection, prepared=False):

--- a/jsonfield/tests.py
+++ b/jsonfield/tests.py
@@ -163,7 +163,7 @@ class JSONFieldTest(TestCase):
         new_obj = JSONModelCustomEncoders.objects.get(pk=obj.pk)
         self.assertEqual(value, new_obj.json)
 
-    def test_django_serializers(self):
+    def _test_django_serializers(self, use_natural_primary_keys):
         """Test serializing/deserializing jsonfield data"""
         for json_obj in [{}, [], 0, '', False, {'key': 'value', 'num': 42,
                                                 'ary': list(range(5)),
@@ -173,27 +173,19 @@ class JSONFieldTest(TestCase):
             self.assert_(new_obj)
 
         queryset = self.json_model.objects.all()
-        ser = serialize('json', queryset)
-        for dobj in deserialize('json', ser):
-            obj = dobj.object
-            pulled = self.json_model.objects.get(id=obj.pk)
-            self.assertEqual(obj.json, pulled.json)
-
-    def test_django_serializers_using_natural_keys(self):
-        """Test serializing/deserializing jsonfield data"""
-        for json_obj in [{}, [], 0, '', False, {'key': 'value', 'num': 42,
-                                                'ary': list(range(5)),
-                                                'dict': {'k': 'v'}}]:
-            obj = self.json_model.objects.create(json=json_obj)
-            new_obj = self.json_model.objects.get(id=obj.id)
-            self.assert_(new_obj)
-
-        queryset = self.json_model.objects.all()
-        ser = serialize('json', queryset, use_natural_primary_keys=True)
+        ser = serialize('json', queryset, use_natural_primary_keys=use_natural_primary_keys)
         for dobj in deserialize('json', ser):
             obj = dobj.object
             pulled = self.json_model.objects.get(natural_id=obj.natural_id)
             self.assertEqual(obj.json, pulled.json)
+
+    def test_django_serializers(self):
+        """Test serializing/deserializing jsonfield data"""
+        self._test_django_serializers(use_natural_primary_keys=False)
+
+    def test_django_serializers_using_natural_keys(self):
+        """Test serializing/deserializing jsonfield data using natural keys"""
+        self._test_django_serializers(use_natural_primary_keys=True)
 
     def test_default_parameters(self):
         """Test providing a default value to the model"""


### PR DESCRIPTION
This is a related issue to https://github.com/bradjasper/django-jsonfield/issues/33 in that the change introduced by https://github.com/bradjasper/django-jsonfield/commit/bf0a41237c6c06771fadcd6cdcf2626679822cc3 breaks Django deserialization of *natural key* objects.

When serializing *natural key* objects using `use_natural_primary_keys=True` the primary key field is not included in the serialized data. Re-serializing them results in the JSON data being stored as encoded JSON strings in the DB.

This PR includes a test to illustrate the issue and also a potential solution. 