### PR TITLE
Raise error with GenericForeignKeys

### DIFF
--- a/jsonfield/tests.py
+++ b/jsonfield/tests.py
@@ -38,7 +38,8 @@ class JSONModelWithForeignKey(models.Model):
     json = JSONField(null=True)
     foreign_obj = GenericForeignKey()
     object_id = models.PositiveIntegerField(blank=True, null=True, db_index=True)
-    content_type = models.ForeignKey(ContentType, blank=True, null=True)
+    content_type = models.ForeignKey(ContentType, blank=True, null=True,
+                                     on_delete=models.CASCADE)
 
 
 class JsonCharModel(models.Model):

--- a/jsonfield/tests.py
+++ b/jsonfield/tests.py
@@ -3,6 +3,8 @@ import django
 from django import forms
 from django.core.serializers import deserialize, serialize
 from django.core.serializers.base import DeserializationError
+from django.contrib.contenttypes.fields import GenericForeignKey
+from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.test import TestCase
 try:
@@ -26,6 +28,17 @@ class JsonModel(models.Model):
     default_json = JSONField(default={"check": 12})
     complex_default_json = JSONField(default=[{"checkcheck": 1212}])
     empty_default = JSONField(default={})
+
+
+class GenericForeignKeyObj(models.Model):
+    name = models.CharField('Foreign Obj', max_length=255, null=True)
+
+
+class JSONModelWithForeignKey(models.Model):
+    json = JSONField(null=True)
+    foreign_obj = GenericForeignKey()
+    object_id = models.PositiveIntegerField(blank=True, null=True, db_index=True)
+    content_type = models.ForeignKey(ContentType, blank=True, null=True)
 
 
 class JsonCharModel(models.Model):
@@ -57,6 +70,12 @@ class JSONModelCustomEncoders(models.Model):
         dump_kwargs={'cls': ComplexEncoder, "indent": 4},
         load_kwargs={'object_hook': as_complex},
     )
+
+
+class JSONModelWithForeignKeyTestCase(TestCase):
+    def test_object_create(self):
+        foreign_obj = GenericForeignKeyObj.objects.create(name='Brain')
+        JSONModelWithForeignKey.objects.create(foreign_obj=foreign_obj)
 
 
 class JSONFieldTest(TestCase):

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ class TestCommand(Command):
         from django.conf import settings
         settings.configure(
             DATABASES={'default': {'NAME': ':memory:', 'ENGINE': 'django.db.backends.sqlite3'}},
-            INSTALLED_APPS=('jsonfield',)
+            INSTALLED_APPS=('jsonfield', 'django.contrib.contenttypes')
         )
         from django.core.management import call_command
         import django


### PR DESCRIPTION
As per the issue #189, creating an object that has both a JSONField and a GenericForeignKey raises the issue [here](https://github.com/dmkoch/django-jsonfield/blob/master/jsonfield/subclassing.py#L35), as per below:

```
  File "/home/tom/django-jsonfield/env/lib/python3.6/site-packages/django/db/models/options.py", line 890, in _property_names
    dir(self.model) if isinstance(getattr(self.model, attr), property)
  File "/home/tom/django-jsonfield/env/lib/python3.6/site-packages/django/db/models/options.py", line 890, in <setcomp>
    dir(self.model) if isinstance(getattr(self.model, attr), property)
  File "/home/tom/django-jsonfield/jsonfield/subclassing.py", line 35, in __get__
    raise AttributeError('Can only be accessed via an instance.')
AttributeError: Can only be accessed via an instance.
```

My PR duplicates the error, but I haven't figured out how to solve.