### PR TITLE
Django 1.11 compatibility, prevents AttributeError

### DIFF
--- a/jsonfield/subclassing.py
+++ b/jsonfield/subclassing.py
@@ -32,7 +32,7 @@ class Creator(object):
 
     def __get__(self, obj, type=None):
         if obj is None:
-            raise AttributeError('Can only be accessed via an instance.')
+            return self
         return obj.__dict__[self.field.name]
 
     def __set__(self, obj, value):


### PR DESCRIPTION
The code was copied from this old file in Django:
https://github.com/django/django/blob/1.6.11/django/db/models/fields/subclassing.py#L31

But Django has since been updated to return `self` instead of raising
`AttributeError`:
https://github.com/django/django/blob/1.7.11/django/db/models/fields/subclassing.py#L33

So reflecting this change in this code now too.

Relevant discussion:
https://github.com/dmkoch/django-jsonfield/issues/189