### PR TITLE
Do not try to deserialize all strings to JSON

### DIFF
--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -78,7 +78,7 @@ class JSONFieldBase(six.with_metaclass(SubfieldBase, models.Field)):
                 # checking if it's empty. This is a special case for South datamigrations
                 # see: https://github.com/bradjasper/django-jsonfield/issues/52
                 if getattr(obj, "pk", None) is not None:
-                    if isinstance(value, six.string_types):
+                    if isinstance(value, six.string_types) and value[0] in ['"', '[', '{']:
                         try:
                             return json.loads(value, **self.load_kwargs)
                         except ValueError:


### PR DESCRIPTION
Previously, the JSONField would try to interpret all strings handed into it as JSON, and pass it to `json.loads` to deserialize the string.

This fails, however, if we want to pass a simple String value in to the field, because that gets interpreted as JSON, and then the JSON serialization fails.

As a remedy, this change updates the JSONField to only interpret strings beginning with `"`, `[`, and `{` as JSON, and save all other strings directly. This still has some edge cases (what if I want to save a this string: `"[hello]"`?) but works for the majority of use cases and improves the developer experience.

Fixes #202 