### PR TITLE
Exclude Django >= 2.0 so pip installs work under Python < 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,8 @@ setup(
     url='https://github.com/dmkoch/django-jsonfield/',
     description='A reusable Django field that allows you to store validated JSON in your model.',
     long_description=open("README.rst").read(),
-    install_requires=['Django >= 1.8.0'],
-    tests_require=['Django >= 1.8.0'],
+    install_requires=['Django >= 1.8.0, < 2.0'],
+    tests_require=['Django >= 1.8.0, < 2.0'],
     cmdclass={'test': TestCommand},
     classifiers=[
         'Environment :: Web Environment',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
     url='https://github.com/dmkoch/django-jsonfield/',
     description='A reusable Django field that allows you to store validated JSON in your model.',
     long_description=open("README.rst").read(),
-    install_requires=['Django >= 1.8.0, < 2.0'],
     tests_require=['Django >= 1.8.0, < 2.0'],
     cmdclass={'test': TestCommand},
     classifiers=[


### PR DESCRIPTION
Right now, jsonfield's requirements resolve to Django 2.0. This causes `pip install jsonfield` to fail under Python 2. This commit will resolve for now.