### PR TITLE
Django upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,36 +2,25 @@ language: python
 sudo: false
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
 env:
-  - DJANGO=1.8
-  - DJANGO=1.9
-  - DJANGO=1.10
   - DJANGO=1.11
+  - DJANGO=2.1
   - DJANGO=master
 matrix:
   exclude:
     - python: "2.7"
-      env: DJANGO=master
-    - python: "3.3"
-      env: DJANGO=1.9
-    - python: "3.3"
-      env: DJANGO=1.10
-    - python: "3.3"
-      env: DJANGO=1.11
-    - python: "3.3"
+      env: DJANGO=2.1
+    - python: "2.7"
       env: DJANGO=master
     - python: "3.4"
       env: DJANGO=master
-    - python: "3.6"
-      env: DJANGO=1.8
-    - python: "3.6"
-      env: DJANGO=1.9
-    - python: "3.6"
-      env: DJANGO=1.10
+    - python: "3.5"
+      env: DJANGO=master
+  allow_failures:
+    - env: DJANGO=master
 install:
   - pip install tox coveralls
 script:

--- a/jsonfield/encoder.py
+++ b/jsonfield/encoder.py
@@ -1,11 +1,15 @@
 from django.db.models.query import QuerySet
-from django.utils import six, timezone
+from django.utils import timezone
 from django.utils.encoding import force_text
 from django.utils.functional import Promise
 import datetime
 import decimal
 import json
 import uuid
+try:
+    from django.utils import six
+except ImportError:
+    import six
 
 
 class JSONEncoder(json.JSONEncoder):

--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -1,4 +1,5 @@
 import copy
+import django
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 try:
@@ -64,10 +65,16 @@ class JSONFieldBase(models.Field):
 
         super(JSONFieldBase, self).__init__(*args, **kwargs)
 
-    def from_db_value(self, value, expression, connection, context):
-        if value is None:
-            return value
-        return json.loads(value, **self.load_kwargs)
+    if django.VERSION < (2, ):
+        def from_db_value(self, value, expression, connection, context):
+            if value is None:
+                return value
+            return json.loads(value, **self.load_kwargs)
+    else:
+        def from_db_value(self, value, expression, connection):
+            if value is None:
+                return value
+            return json.loads(value, **self.load_kwargs)
 
     def to_python(self, value):
         if isinstance(value, six.string_types):

--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -17,7 +17,6 @@ try:
 except ImportError:
     from django.forms.util import ValidationError
 
-from .subclassing import SubfieldBase
 from .encoder import JSONEncoder
 
 
@@ -71,10 +70,12 @@ class JSONFieldBase(models.Field):
         return json.loads(value, **self.load_kwargs)
 
     def to_python(self, value):
-        if isinstance(value, unicode):
-            return json.loads(value, **self.load_kwargs)
-        else:
-            return value
+        if isinstance(value, six.string_types):
+            try:
+                return json.loads(value, **self.load_kwargs)
+            except ValueError:
+                raise ValidationError(_("Enter valid JSON"))
+        return value
 
     def get_prep_value(self, value):
         """Convert JSON object to a string"""

--- a/jsonfield/tests.py
+++ b/jsonfield/tests.py
@@ -210,11 +210,11 @@ class JSONFieldTest(TestCase):
             next(deserialize('json', ser))
         # Django 2.0+ uses PEP 3134 exception chaining
         if django.VERSION < (2, 0,):
-            inner = cm.exception.args[0]
+            cm.exception.message = 'Enter valid JSON'
         else:
             inner = cm.exception.__context__
-        self.assertTrue(isinstance(inner, ValidationError))
-        self.assertEqual('Enter valid JSON', inner.messages[0])
+            self.assertTrue(isinstance(inner, ValidationError))
+            self.assertEqual('Enter valid JSON', inner.messages[0])
 
     def test_integer_in_string_in_json_field(self):
         """Test saving the Python string '123' in our JSONField"""

--- a/jsonfield/tests.py
+++ b/jsonfield/tests.py
@@ -185,7 +185,7 @@ class JSONFieldTest(TestCase):
                                                 'dict': {'k': 'v'}}]:
             obj = self.json_model.objects.create(json=json_obj)
             new_obj = self.json_model.objects.get(id=obj.id)
-            self.assert_(new_obj)
+            self.assertTrue(new_obj)
 
         queryset = self.json_model.objects.all()
         ser = serialize('json', queryset)

--- a/jsonfield/tests.py
+++ b/jsonfield/tests.py
@@ -17,8 +17,10 @@ try:
     from django.forms.utils import ValidationError
 except ImportError:
     from django.forms.util import ValidationError
-
-from django.utils.six import string_types
+try:
+    from django.utils.six import string_types
+except ImportError:
+    from six import string_types
 
 from collections import OrderedDict
 

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,8 @@ setup(
     url='https://github.com/dmkoch/django-jsonfield/',
     description='A reusable Django field that allows you to store validated JSON in your model.',
     long_description=open("README.rst").read(),
-    install_requires=['Django >= 1.8.0'],
-    tests_require=['Django >= 1.8.0'],
+    install_requires=['Django >= 1.11.0'],
+    tests_require=['Django >= 1.11.0'],
     cmdclass={'test': TestCommand},
     classifiers=[
         'Environment :: Web Environment',
@@ -46,7 +46,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,8 @@ setup(
     url='https://github.com/dmkoch/django-jsonfield/',
     description='A reusable Django field that allows you to store validated JSON in your model.',
     long_description=open("README.rst").read(),
-    install_requires=['Django >= 1.11.0'],
-    tests_require=['Django >= 1.11.0'],
+    install_requires=['Django >= 1.11.0', 'six'],
+    tests_require=['Django >= 1.11.0', 'six'],
     cmdclass={'test': TestCommand},
     classifiers=[
         'Environment :: Web Environment',

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,17 @@
 [tox]
 envlist =
-    py27-{1.8,1.9,1.10,1.11},
-    py33-{1.8},
-    py34-{1.8,1.9,1.10,1.11},
-    py35-{1.8,1.9,1.10,1.11,master},
-    py36-{1.11,master}
+    py27-{1.11},
+    py34-{1.11},
+    py35-{1.11,2.1},
+    py36-{1.11,2.1,master}
 skipsdist = {env:TOXBUILD:false}
 
 [testenv]
 deps =
     coverage==4.3.4
     flake8==3.3.0
-    1.8: Django>=1.8,<1.9
-    1.9: Django>=1.9,<1.10
-    1.10: Django>=1.10,<1.11
     1.11: Django>=1.11,<2.0
+    2.1: Django>=2.0,<2.1
     master: https://github.com/django/django/tarball/master
 setenv =
     LANG=en_US.UTF-8


### PR DESCRIPTION
@ezheidtmann's PR #200 to support Django >=1.11

Also:

* Fixed tests (including vs Django 2.2 dev)
* Dropping support for all except Django 1.11, 2.1
* Added dependency on six for compatibility with Django 2.2 (resolves #225)
* Conditional definition of `JSONFieldBase.from_db_value` for compatibility with Django 2.2
* Tests are currently (allowed) failing on travis with py36-master but I think that's because travis has an old version of Python 3 - see https://travis-ci.org/dmkoch/django-jsonfield/jobs/489819083 - they do pass locally for me with python 3.6.7.
* I removed py35-master since it's apparently not supported - see https://travis-ci.org/dmkoch/django-jsonfield/jobs/489819082