### PR TITLE
RFC 7159 support

### DIFF
--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -34,6 +34,20 @@ class JSONFormFieldBase(object):
         if not value and not self.required:
             return None
 
+        # RFC 7159
+        if value == 'true':
+            return True
+        if value == 'false':
+            return False
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            pass
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            pass
+
         # Trap cleaning errors & bubble them up as JSON errors
         try:
             return super(JSONFormFieldBase, self).clean(value)
@@ -161,3 +175,10 @@ class JSONCharField(JSONFieldBase, models.CharField):
     stored in the database like a CharField, which enables it to be used
     e.g. in unique keys"""
     form_class = JSONCharFormField
+
+
+try:
+    from south.modelsinspector import add_introspection_rules
+    add_introspection_rules([], [r"^jsonfield\.fields\.(JSONField|JSONCharField)"])
+except ImportError:
+    pass

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,34 @@ from distutils.core import Command
 from setuptools import setup
 
 
+class TestCommand(Command):
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        from django.conf import settings
+        settings.configure(
+            DATABASES={'default': {'NAME': ':memory:', 'ENGINE': 'django.db.backends.sqlite3'}},
+            INSTALLED_APPS=('jsonfield', 'django.contrib.contenttypes')
+        )
+        from django.core.management import call_command
+        import django
+
+        if django.VERSION[:2] >= (1, 7):
+            django.setup()
+        call_command('makemigrations')
+        call_command('migrate')
+        call_command('test', 'jsonfield')
+
+
 setup(
     name='jsonfield',
-    version='2.1.0',
+    version='2.1.1',
     packages=['jsonfield'],
     license='MIT',
     include_package_data=True,

--- a/tests/test_jsonfield.py
+++ b/tests/test_jsonfield.py
@@ -221,6 +221,20 @@ class JSONFieldTest(TestCase):
         model1.save()
         self.assertEqual(model1.empty_default, {"hey": "now"})
 
+    def test_rfc7159_spec(self):
+        """Tests that JSON can be a literal (null/true/false) or a number too"""
+        values = [
+            None,
+            True,
+            False,
+            0.125,
+        ]
+
+        for value in values:
+            obj = self.json_model.objects.create(json=value)
+            new_obj = self.json_model.objects.get(id=obj.id)
+            self.assertEqual(new_obj.json, value)
+
 
 class JSONCharFieldTest(JSONFieldTest):
     json_model = JsonCharModel


### PR DESCRIPTION
- RFC 7159 support  (#220)
- `py33` support drop (https://devguide.python.org/devcycle/#end-of-life-branches + virtualenv / pyenv wheel problem)
- `py37` tox env added
- django 1.8..2.2+ compatibility fixes (e.g. `six`)
- `coverage` + `flake8` versions upgrade