### PR TITLE
support django 3.0

### DIFF
--- a/jsonfield/encoder.py
+++ b/jsonfield/encoder.py
@@ -1,5 +1,10 @@
 from django.db.models.query import QuerySet
-from django.utils import six, timezone
+from django.utils import timezone
+try:
+    from django.utils import six
+except ImportError:
+    import six
+
 from django.utils.encoding import force_text
 from django.utils.functional import Promise
 import datetime

--- a/jsonfield/tests.py
+++ b/jsonfield/tests.py
@@ -18,7 +18,10 @@ try:
 except ImportError:
     from django.forms.util import ValidationError
 
-from django.utils.six import string_types
+try:
+    from django.utils.six import string_types
+except ImportError:
+    from six import string_types
 
 from collections import OrderedDict
 


### PR DESCRIPTION
django.utils.six is deprecated from django 3.0